### PR TITLE
fix: allow to infer union type that contains undefined as payload

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -4,7 +4,7 @@ import { Module } from './module'
 
 export class Getters<S = {}> {
   /* @internal */
-  __ctx__!: Context<Module<S, this, BM0, BA0>>
+  __ctx__!: Context<Module<S, this, any, any>>
 
   $init(_store: Store<any>): void {}
 
@@ -19,7 +19,7 @@ export class Getters<S = {}> {
 
 export class Mutations<S = {}> {
   /* @internal */
-  __ctx__!: Context<Module<S, BG0, BM0, BA0>>
+  __ctx__!: Context<Module<S, any, any, any>>
 
   protected get state(): S {
     return this.__ctx__.state
@@ -28,8 +28,8 @@ export class Mutations<S = {}> {
 
 export class Actions<
   S = {},
-  G extends BG0 = Getters,
-  M extends BM0 = Mutations,
+  G extends BG<S> = BG<S>,
+  M extends BM<S> = BM<S>,
   A = {} // We need to specify self action type explicitly to infer dispatch type.
 > {
   /* @internal */
@@ -55,14 +55,12 @@ export class Actions<
 }
 
 // Type aliases for internal use
-export type BG0 = Getters
-export type BG1<S> = Getters<S>
-export type BM0 = Mutations
-export type BA0 = Actions
-export type BA1<S, G extends BG0, M extends BM0> = Actions<S, G, M>
+export type BG<S> = Getters<S>
+export type BM<S> = Mutations<S>
+export type BA<S, G extends BG<S>, M extends BM<S>> = Actions<S, G, M>
 
-export type Payload<T> = T extends () => any
-  ? undefined
+export type Payload<T> = T extends (payload?: infer P) => any
+  ? P | undefined
   : T extends (payload: infer P) => any
   ? P
   : never

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,12 +5,12 @@ import {
   MutationTree,
   ActionTree
 } from 'vuex'
-import { BG0, BM0, BA0, Payload } from './assets'
+import { Payload, BA, BG, BM } from './assets'
 import { assert, Class, mapValues, noop, combine } from './utils'
 import { Context, ContextPosition, Commit, Dispatch } from './context'
 import { ComponentMapper } from './mapper'
 
-export type MappedFunction<Fn, R> = Payload<Fn> extends undefined
+export type MappedFunction<Fn, R> = undefined extends Payload<Fn>
   ? (payload?: Payload<Fn>) => R
   : (payload: Payload<Fn>) => R
 
@@ -18,7 +18,12 @@ export type RestArgs<Fn> = Fn extends (_: any, ...args: infer R) => any
   ? R
   : never
 
-export interface ModuleOptions<S, G extends BG0, M extends BM0, A extends BA0> {
+export interface ModuleOptions<
+  S,
+  G extends BG<S>,
+  M extends BM<S>,
+  A extends BA<S, G, M>
+> {
   namespaced?: boolean
   state?: Class<S>
   getters?: Class<G>
@@ -32,7 +37,12 @@ interface ModuleInstance {
   injectStore: (store: Store<any>) => void
 }
 
-export class Module<S, G extends BG0, M extends BM0, A extends BA0> {
+export class Module<
+  S,
+  G extends BG<S>,
+  M extends BM<S>,
+  A extends BA<S, G, M>
+> {
   /* @internal */
   path: string[] | undefined
 
@@ -194,7 +204,12 @@ function createLazyContextPosition(
   }
 }
 
-function initGetters<S, G extends BG0, M extends BM0, A extends BA0>(
+function initGetters<
+  S,
+  G extends BG<S>,
+  M extends BM<S>,
+  A extends BA<S, G, M>
+>(
   Getters: Class<G>,
   module: Module<S, G, M, A>
 ): { getters: GetterTree<any, any>; injectStore: (store: Store<any>) => void } {
@@ -229,7 +244,12 @@ function initGetters<S, G extends BG0, M extends BM0, A extends BA0>(
   }
 }
 
-function initMutations<S, G extends BG0, M extends BM0, A extends BA0>(
+function initMutations<
+  S,
+  G extends BG<S>,
+  M extends BM<S>,
+  A extends BA<S, G, M>
+>(
   Mutations: Class<M>,
   module: Module<S, G, M, A>
 ): { mutations: MutationTree<any>; injectStore: (store: Store<any>) => void } {
@@ -258,7 +278,12 @@ function initMutations<S, G extends BG0, M extends BM0, A extends BA0>(
   }
 }
 
-function initActions<S, G extends BG0, M extends BM0, A extends BA0>(
+function initActions<
+  S,
+  G extends BG<S>,
+  M extends BM<S>,
+  A extends BA<S, G, M>
+>(
   Actions: Class<A>,
   module: Module<S, G, M, A>
 ): { actions: ActionTree<any, any>; injectStore: (store: Store<any>) => void } {

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -1,3 +1,6 @@
+// Compilation check
+import './types'
+
 import * as assert from 'power-assert'
 import Vue from 'vue'
 import * as Vuex from 'vuex'

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,30 @@
+/**
+ * This file is to test whether types would pass compilation.
+ */
+
+import { Mutations, Actions, Module, createStore, Getters } from '../src'
+
+export function shouldInferUnionTypeContainsUndefined() {
+  class TestMutations extends Mutations {
+    test(_test = true) {}
+  }
+
+  class TestActions extends Actions<{}, Getters, TestMutations> {
+    test(_test = true) {}
+    foo() {}
+  }
+
+  const test = new Module({
+    mutations: TestMutations,
+    actions: TestActions
+  })
+
+  const store = createStore(test)
+
+  const ctx = test.context(store)
+
+  ctx.dispatch('test', undefined)
+  ctx.dispatch('test', false)
+  ctx.commit('test', undefined)
+  ctx.commit('test', false)
+}


### PR DESCRIPTION
Currently it cannot infer union type that contains `undefined` of action / mutation payload.

```ts
class TestMutations extends Mutations {
  test(foo?: boolean) {}
}

const test = new Module({ mutations: TestMutations })

const ctx = test.context(store)

ctx.commit('test', true) // error
```

This is because conditional type in the `Payload` type is incorrect. It does not handle the payload is an union type of `undefined`.

I also made module type parameters more strict to pass compilation of this lib.