### PR TITLE
feat: expose module options for testability

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ it('calls increment mutation', () => {
   shallowMount(Counter, { store, localVue }).trigger('click')
 
   // check the mock function was called
-  expect(spy).toHaveBeenCalled(spy)
+  expect(spy).toHaveBeenCalled()
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ import counter, { CounterMutations } from '@/store/modules/counter'
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
-// make sure that you clean mocked object
+// make sure that you clean mocked object after each test case
 const originalMutations = counter.options.mutations
 afterEach(() => {
   counter.options.mutations = originalMutations

--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ export default Vue.extend({
 In the spec file, mock the `mutations` option in the `counter` module. The below is [Jest](https://jestjs.io/) example but the essential idea is the same:
 
 ```ts
-import { shallowMount } from '@vue/test-utils'
+import * as Vuex from 'vuex'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
 import { createStore } from 'vuex-smart-module'
 
 // component which we want to test
@@ -338,6 +339,9 @@ import Counter from '@/components/Counter.vue'
 
 // counter module which we want to mock
 import counter, { CounterMutations } from '@/store/modules/counter'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
 
 // make sure that you clean mocked object
 const originalMutations = counter.options.mutations
@@ -364,7 +368,7 @@ it('calls increment mutation', () => {
   const store = createStore(counter)
 
   // emulate click event
-  shallowMount(Counter).trigger('click')
+  shallowMount(Counter, { store, localVue }).trigger('click')
 
   // check the mock function was called
   expect(spy).toHaveBeenCalled(spy)

--- a/README.md
+++ b/README.md
@@ -306,6 +306,71 @@ export default Vue.extend({
 })
 ```
 
+## Testing
+
+When you want to mock some module assets, you can directly inject mock constructor into module options. For example, you will test the following component which is using `counter` module:
+
+```vue
+<template>
+  <button @click="increment">Increment</button>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+// use counter module
+import counter from '@/store/modules/counter'
+
+export default Vue.extend({
+  methods: counter.mapMutations(['increment'])
+})
+</script>
+```
+
+In the spec file, mock the `mutations` option in the `counter` module. The below is [Jest](https://jestjs.io/) example but the essential idea is the same:
+
+```ts
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex-smart-module'
+
+// component which we want to test
+import Counter from '@/components/Counter.vue'
+
+// counter module which we want to mock
+import counter, { CounterMutations } from '@/store/modules/counter'
+
+// make sure that you clean mocked object
+const originalMutations = counter.options.mutations
+afterEach(() => {
+  counter.options.mutations = originalMutations
+})
+
+it('calls increment mutation', () => {
+  // create spy
+  const spy = jest.fn()
+
+  // create mock mutation
+  class MockMutations extends CounterMutations {
+    // override increment method for mock
+    increment() {
+      spy()
+    }
+  }
+
+  // inject mock
+  counter.options.mutations = MockMutations
+
+  // create mock store
+  const store = createStore(counter)
+
+  // emulate click event
+  shallowMount(Counter).trigger('click')
+
+  // check the mock function was called
+  expect(spy).toHaveBeenCalled(spy)
+})
+```
+
 ## License
 
 MIT

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,7 +53,7 @@ export class Module<
     createLazyContextPosition(this)
   )
 
-  constructor(private options: ModuleOptions<S, G, M, A> = {}) {}
+  constructor(public options: ModuleOptions<S, G, M, A> = {}) {}
 
   clone(): Module<S, G, M, A> {
     const options = { ...this.options }

--- a/test/testability.spec.ts
+++ b/test/testability.spec.ts
@@ -1,0 +1,41 @@
+import * as Vuex from 'vuex'
+import { Module, Mutations, createStore } from '../src'
+import { createLocalVue } from '@vue/test-utils'
+
+class TestState {
+  count = 0
+}
+
+class TestMutations extends Mutations<TestState> {
+  inc() {
+    this.state.count++
+  }
+}
+
+const test = new Module({
+  state: TestState,
+  mutations: TestMutations
+})
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('testability', () => {
+  const originalMutations = test.options.mutations
+  afterEach(() => {
+    test.options.mutations = originalMutations
+  })
+
+  it('can mock module options', done => {
+    class MockMutations extends TestMutations {
+      inc() {
+        done()
+      }
+    }
+
+    test.options.mutations = MockMutations
+    const store = createStore(test)
+
+    store.commit('inc')
+  })
+})


### PR DESCRIPTION
Exposed the `Module#options` property to let the users inject some mock object for testing purpose.

I also added Testing section in readme to describe how to utilize the `options` property in testing. 