### PR TITLE
feat:  add inject helper to test assets easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ class FooActions extends Actions<
 
     return new Promise(resolve => {
       setTimeout(() => {
-        this.commit('inc', payload.amount)
+        this.commit('increment', payload.amount)
       }, payload.interval)
     })
   }
@@ -338,6 +338,45 @@ export default Vue.extend({
 ```
 
 ## Testing
+
+### Unit testing getters, mutations and actions
+
+vuex-smart-module provides `inject` helper function which allow you to inject mock dependencies into getters, mutations and actions instance. You can inject any properties for test:
+
+```ts
+import { inject } from 'vuex-smart-module'
+import { FooGetters, FooActions } from '@/store/modules/foo'
+
+it('returns doubled value', () => {
+  // Inject mock state into getters
+  const getters = inject(FooGetters, {
+    state: {
+      count: 5
+    }
+  })
+
+  // Test double getter
+  expect(getters.double).toBe(10)
+})
+
+it('increments asynchronously', async () => {
+  // Inject mock commit method
+  const commit = jest.fn()
+  const actions = inject(FooActions, {
+    commit
+  })
+
+  await actions.incrementAsync({
+    amount: 3
+    interval: 1
+  })
+
+  // Check mock commit method is called
+  expect(commit).toHaveBeenCalledWith('increment', 3)
+})
+```
+
+### Mocking modules to test components
 
 When you want to mock some module assets, you can directly inject mock constructor into module options. For example, you will test the following component which is using `counter` module:
 

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -2,6 +2,41 @@ import { Store } from 'vuex'
 import { Commit, Dispatch, Context } from './context'
 import { Module } from './module'
 
+interface Class<T> {
+  new (...args: any[]): T
+}
+
+export function inject<G extends Getters<S>, S>(
+  Getters: Class<G>,
+  injection: Partial<G & { state: S; getters: G }>
+): G
+export function inject<M extends Mutations<S>, S>(
+  Mutations: Class<M>,
+  injection: Partial<M & { state: S }>
+): M
+export function inject<A extends Actions<S, G, any, any>, S, G extends BG<S>>(
+  Actions: Class<A>,
+  injection: Partial<A & { state: S; getters: G; dispatch: any; commit: any }>
+): A
+export function inject<T>(
+  F: Class<T>,
+  injection: Partial<T> & Record<string, any>
+): T {
+  const proto = F.prototype
+
+  const descs: PropertyDescriptorMap = {}
+  Object.keys(injection).forEach(key => {
+    descs[key] = {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: injection[key]
+    }
+  })
+
+  return Object.create(proto, descs)
+}
+
 export class Getters<S = {}> {
   /* @internal */
   __ctx__!: Context<Module<S, this, any, any>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Store, StoreOptions } from 'vuex'
 import { Module } from './module'
 
-export { Getters, Mutations, Actions } from './assets'
+export { Getters, Mutations, Actions, inject } from './assets'
 export { Dispatch, Commit, Context } from './context'
 export { registerModule, unregisterModule } from './register'
 export { Module }


### PR DESCRIPTION
This PR adds `inject` helper function to make testing for getters, mutations and actions instance easier.

rendered docs: https://github.com/ktsn/vuex-smart-module/blob/7cb17a7b4f6ce041e5f190261c08770861d1f221/README.md#unit-testing-getters-mutations-and-actions