### PR TITLE
fix: local getters should not include empty getter

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "testem": "^2.14.0",
     "ts-loader": "^5.3.3",
     "tslib": "^1.9.3",
-    "typescript": "^3.3.3",
+    "typescript": "~3.3.3",
     "uglify-js": "^3.4.9",
     "vue": "^2.6.6",
     "vue-template-compiler": "^2.6.6",

--- a/src/context.ts
+++ b/src/context.ts
@@ -113,9 +113,9 @@ export function getters(store: Store<any>, namespace: string): any {
   const getters: Record<string, any> = {}
 
   Object.keys(store.getters).forEach(key => {
-    const sameNamespace = namespace !== key.slice(0, sliceIndex)
+    const sameNamespace = namespace === key.slice(0, sliceIndex)
     const name = key.slice(sliceIndex)
-    if (sameNamespace && name) {
+    if (!sameNamespace || !name) {
       return
     }
 

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -470,6 +470,44 @@ describe('Module', () => {
 
       assert(store.getters['test/triple'] === 3)
     })
+
+    it('edge case: local getters should not try to register an empty getter', () => {
+      class FooGetters extends Getters {
+        get test() {
+          return 1
+        }
+      }
+
+      class BarGetters extends Getters {
+        get a() {
+          return 2
+        }
+
+        get b() {
+          return 3
+        }
+      }
+
+      const foo = new Module({
+        getters: FooGetters
+      })
+
+      const bar = new Module({
+        namespaced: false,
+        getters: BarGetters
+      })
+
+      const store = createStore(
+        new Module({
+          modules: {
+            foo,
+            bar
+          }
+        })
+      )
+
+      assert(foo.context(store).getters.test === 1)
+    })
   })
 
   it("can be used in other module's action", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4810,10 +4810,10 @@ typescript-eslint-parser@^18.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3.tgz#f1657fc7daa27e1a8930758ace9ae8da31403221"
-  integrity sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
+typescript@~3.3.3:
+  version "3.3.4000"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
 uglify-js@^3.4.9:
   version "3.4.9"


### PR DESCRIPTION
The current local getters object generation logic is incorrect. It may accidentally pass other namespace getters and occur 'cannot redeclare property' error.

This is because the current condition in `context.ts` will pass if the target getter is not under the target namespace and derived name is empty.