### PR TITLE
support sinai style dispatch

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,6 +1,6 @@
 import { Store } from 'vuex'
 import { Commit, Dispatch, Context } from './context'
-import { Module } from './module'
+import { Module, MappedFunction } from './module'
 
 interface Class<T> {
   new (...args: any[]): T
@@ -87,6 +87,26 @@ export class Actions<
   protected get dispatch(): Dispatch<A> {
     return this.__ctx__.dispatch
   }
+
+  protected get actions(): Dispatcher<A> {
+    return this.__ctx__.actions
+  }
+
+  protected get mutations(): Committer<M> {
+    return this.__ctx__.mutations
+  }
+}
+
+export type Committer<M> = {
+  [K in keyof M]: Payload<M[K]> extends never
+    ? never
+    : MappedFunction<M[K], void>
+}
+
+export type Dispatcher<A> = {
+  [K in keyof A]: Payload<A[K]> extends never
+    ? never
+    : MappedFunction<A[K], Promise<any>>
 }
 
 // Type aliases for internal use

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,14 @@ import {
   BG,
   BM
 } from './assets'
-import { assert, Class, mapValues, noop, combine } from './utils'
+import {
+  assert,
+  Class,
+  mapValues,
+  noop,
+  combine,
+  traverseDescriptors
+} from './utils'
 import { Context, ContextPosition, Commit, Dispatch } from './context'
 import { ComponentMapper } from './mapper'
 
@@ -312,26 +319,4 @@ function initActions<
       actions.$init(store)
     }
   }
-}
-
-function traverseDescriptors(
-  proto: Object,
-  Base: Function,
-  fn: (desc: PropertyDescriptor, key: string) => void,
-  exclude: Record<string, boolean> = { constructor: true }
-): void {
-  if (proto.constructor === Base) {
-    return
-  }
-
-  Object.getOwnPropertyNames(proto).forEach(key => {
-    // Ensure to only choose most extended properties
-    if (exclude[key]) return
-    exclude[key] = true
-
-    const desc = Object.getOwnPropertyDescriptor(proto, key)!
-    fn(desc, key)
-  })
-
-  traverseDescriptors(Object.getPrototypeOf(proto), Base, fn, exclude)
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -79,7 +79,12 @@ export class Module<
   }
 
   context(store: Store<any>): Context<this> {
-    return new Context(createLazyContextPosition(this), store)
+    return new Context(
+      createLazyContextPosition(this),
+      store,
+      this.options.mutations,
+      this.options.actions
+    )
   }
 
   mapState<K extends keyof S>(map: K[]): { [Key in K]: () => S[Key] }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,25 @@ export function assert(condition: any, message: string): void {
     throw new Error(`[vuex-smart-module] ${message}`)
   }
 }
+
+export function traverseDescriptors(
+  proto: Object,
+  Base: Function,
+  fn: (desc: PropertyDescriptor, key: string) => void,
+  exclude: Record<string, boolean> = { constructor: true }
+): void {
+  if (proto.constructor === Base) {
+    return
+  }
+
+  Object.getOwnPropertyNames(proto).forEach(key => {
+    // Ensure to only choose most extended properties
+    if (exclude[key]) return
+    exclude[key] = true
+
+    const desc = Object.getOwnPropertyDescriptor(proto, key)!
+    fn(desc, key)
+  })
+
+  traverseDescriptors(Object.getPrototypeOf(proto), Base, fn, exclude)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,3 +54,14 @@ export function traverseDescriptors(
 
   traverseDescriptors(Object.getPrototypeOf(proto), Base, fn, exclude)
 }
+
+export function gatherHandlerNames(proto: Object, Base: Function): string[] {
+  const ret: string[] = []
+  traverseDescriptors(proto, Base, (desc, name) => {
+    if (typeof desc.value !== 'function') {
+      return
+    }
+    ret.push(name)
+  })
+  return ret
+}


### PR DESCRIPTION
This PR makes enable to commit / dispatch by sinai style.

```typescript
const foo = fooModule.context(store);

foo.mutations.inc()  // equivalent to foo.commit('inc', undefined)
foo.actions.inc() // equivalent to foo.dispatch('inc', undefined)
```

One of advantages of this style is that we can jump to implementation by "Go to definition".
