### PR TITLE
feat: support dispatch/commit without payload

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -10,27 +10,39 @@ import { get, Class, gatherHandlerNames, assert } from './utils'
 import { Module } from './module'
 
 export interface Commit<M> {
+  // type and payload separate
   <K extends keyof M>(
     type: K,
     payload: Payload<M[K]>,
     options?: CommitOptions
   ): void
+  // type part of payload
   <K extends keyof M>(
     payload: Payload<M[K]> & { type: K },
     options?: CommitOptions
   ): void
+  // no payload (only mutations without parameters)
+  <K extends { [K in keyof M]: M[K] extends () => any ? K : never }[keyof M]>(
+    type: K
+  ): void
 }
 
 export interface Dispatch<A> {
+  // type and payload separate
   <K extends keyof A>(
     type: K,
     payload: Payload<A[K]>,
     options?: DispatchOptions
   ): Promise<any>
+  // type part of payload
   <K extends keyof A>(
     payload: Payload<A[K]> & { type: K },
     options?: DispatchOptions
   ): Promise<any>
+  // no payload (only actions without parameters)
+  <K extends { [K in keyof A]: A[K] extends () => any ? K : never }[keyof A]>(
+    type: K
+  ): void
 }
 
 type State<Mod extends Module<any, any, any, any>> = Mod extends Module<

--- a/test/types.ts
+++ b/test/types.ts
@@ -54,3 +54,25 @@ export function canDeclareRecursiveModuleType() {
     }
   })
 }
+
+export function canDispatchOrCommitWithoutPayload() {
+  class TestMutations extends Mutations {
+    test() {}
+  }
+
+  class TestActions extends Actions<{}, Getters, TestMutations> {
+    test() {}
+  }
+
+  const test = new Module({
+    mutations: TestMutations,
+    actions: TestActions
+  })
+
+  const store = createStore(test)
+
+  const ctx = test.context(store)
+
+  ctx.dispatch('test')
+  ctx.commit('test')
+}


### PR DESCRIPTION
This probably makes more sense for actions than for mutations, but the `Commit` and `Dispatch` types are so similar that it seems strange to only add it to one of them.

The type signature is based on the “Conditional types are particularly useful when combined with mapped types” example in the [Advanced Types section of the TypeScript handbook](https://www.typescriptlang.org/docs/handbook/advanced-types.html).