### PR TITLE
feat: add nested modules context

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,52 @@ const root = new Module({
 const store = createStore(root)
 ```
 
+### Nested Module Context
+
+When there are nested modules in your module, you can access them through a module context.
+
+Let's say you have three modules: counter, todo and root where the root module has former two modules as nested modules:
+
+```ts
+import { Module, createStore } from 'vuex-smart-module'
+
+// Counter module
+const counter = new Module({
+  // ...
+})
+
+// Todo module
+const todo = new Module({
+  // ...
+})
+
+// Root module
+const root = new Module({
+  modules: {
+    counter,
+    todo
+  }
+})
+
+export const store = createStore(root)
+```
+
+You can access counter and todo contexts through the root context by using `modules` property.
+
+```ts
+import { root, store } from './store'
+
+// Get root context
+const ctx = root.context(store)
+
+// You can access counter and todo context through `modules` as well
+const counterCtx = ctx.modules.counter
+const todoCtx = ctx.modules.todo
+
+counterCtx.dispatch('increment')
+todoCtx.dispatch('fetchTodos')
+```
+
 ### Register Module Dynamically
 
 You can use `registerModule` to register a module and `unregisterModule` to unregister it.

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -48,7 +48,7 @@ export function inject<T>(
 
 export class Getters<S = {}> {
   /* @internal */
-  __ctx__!: Context<Module<S, this, any, any>>
+  __ctx__!: Context<Module<S, this, any, any, any>>
 
   $init(_store: Store<any>): void {}
 
@@ -63,7 +63,7 @@ export class Getters<S = {}> {
 
 export class Mutations<S = {}> {
   /* @internal */
-  __ctx__!: Context<Module<S, any, any, any>>
+  __ctx__!: Context<Module<S, any, any, any, any>>
 
   protected get state(): S {
     return this.__ctx__.state
@@ -77,7 +77,7 @@ export class Actions<
   A = {} // We need to specify self action type explicitly to infer dispatch type.
 > {
   /* @internal */
-  __ctx__!: Context<Module<S, G, M, any>>
+  __ctx__!: Context<Module<S, G, M, any, any>>
 
   $init(_store: Store<any>): void {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { hotUpdate } from './module'
 export { Module }
 
 export function createStore(
-  rootModule: Module<any, any, any, any>,
+  rootModule: Module<any, any, any, any, any>,
   options: StoreOptions<any> = {}
 ): Store<any> {
   const rootModuleOptions = rootModule.getStoreOptions()

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -25,7 +25,7 @@ export function createMapper<
   G extends BG<S>,
   M extends BM<S>,
   A extends BA<S, G, M>
->(module: Module<S, G, M, A>): ComponentMapper<S, G, M, A> {
+>(module: Module<S, G, M, A, any>): ComponentMapper<S, G, M, A> {
   return new ComponentMapper(createLazyContextPosition(module))
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -31,7 +31,7 @@ export interface ModuleOptions<
   G extends BG<S>,
   M extends BM<S>,
   A extends BA<S, G, M>,
-  Modules extends Record<string, Module<any, any, any, any, any>>
+  Modules extends Record<string, Module<any, any, any, any, any>> = {}
 > {
   namespaced?: boolean
   state?: Class<S>
@@ -51,7 +51,7 @@ export class Module<
   G extends BG<S>,
   M extends BM<S>,
   A extends BA<S, G, M>,
-  Modules extends Record<string, Module<any, any, any, any, any>>
+  Modules extends Record<string, Module<any, any, any, any, any>> = {}
 > {
   /* @internal */
   path: string[] | undefined

--- a/src/module.ts
+++ b/src/module.ts
@@ -30,14 +30,15 @@ export interface ModuleOptions<
   S,
   G extends BG<S>,
   M extends BM<S>,
-  A extends BA<S, G, M>
+  A extends BA<S, G, M>,
+  Modules extends Record<string, Module<any, any, any, any, any>>
 > {
   namespaced?: boolean
   state?: Class<S>
   getters?: Class<G>
   mutations?: Class<M>
   actions?: Class<A>
-  modules?: Record<string, Module<any, any, any, any>>
+  modules?: Modules
 }
 
 interface ModuleInstance {
@@ -49,7 +50,8 @@ export class Module<
   S,
   G extends BG<S>,
   M extends BM<S>,
-  A extends BA<S, G, M>
+  A extends BA<S, G, M>,
+  Modules extends Record<string, Module<any, any, any, any, any>>
 > {
   /* @internal */
   path: string[] | undefined
@@ -61,23 +63,18 @@ export class Module<
     createLazyContextPosition(this)
   )
 
-  constructor(public options: ModuleOptions<S, G, M, A> = {}) {}
+  constructor(public options: ModuleOptions<S, G, M, A, Modules> = {}) {}
 
-  clone(): Module<S, G, M, A> {
+  clone(): Module<S, G, M, A, Modules> {
     const options = { ...this.options }
     if (options.modules) {
-      options.modules = mapValues(options.modules, (m) => m.clone())
+      options.modules = mapValues(options.modules, (m) => m.clone()) as Modules
     }
     return new Module(options)
   }
 
   context(store: Store<any>): Context<this> {
-    return new Context(
-      createLazyContextPosition(this),
-      store,
-      this.options.mutations,
-      this.options.actions
-    )
+    return new Context(createLazyContextPosition(this), store, this.options)
   }
 
   mapState<K extends keyof S>(map: K[]): { [Key in K]: () => S[Key] }
@@ -214,7 +211,7 @@ export class Module<
 
 export function hotUpdate(
   store: Store<unknown>,
-  module: Module<any, any, any, any>
+  module: Module<any, any, any, any, any>
 ): void {
   const { options, injectStore } = module.create([], '')
   store.hotUpdate(options)
@@ -225,10 +222,11 @@ function initGetters<
   S,
   G extends BG<S>,
   M extends BM<S>,
-  A extends BA<S, G, M>
+  A extends BA<S, G, M>,
+  Modules extends Record<string, Module<any, any, any, any, any>>
 >(
   Getters: Class<G>,
-  module: Module<S, G, M, A>
+  module: Module<S, G, M, A, Modules>
 ): { getters: GetterTree<any, any>; injectStore: (store: Store<any>) => void } {
   const getters: any = new Getters()
   const options: GetterTree<any, any> = {}
@@ -294,10 +292,11 @@ function initMutations<
   S,
   G extends BG<S>,
   M extends BM<S>,
-  A extends BA<S, G, M>
+  A extends BA<S, G, M>,
+  Modules extends Record<string, Module<any, any, any, any, any>>
 >(
   Mutations: Class<M>,
-  module: Module<S, G, M, A>
+  module: Module<S, G, M, A, Modules>
 ): { mutations: MutationTree<any>; injectStore: (store: Store<any>) => void } {
   const mutations: any = new Mutations()
   const options: MutationTree<any> = {}
@@ -348,10 +347,11 @@ function initActions<
   S,
   G extends BG<S>,
   M extends BM<S>,
-  A extends BA<S, G, M>
+  A extends BA<S, G, M>,
+  Modules extends Record<string, Module<any, any, any, any, any>>
 >(
   Actions: Class<A>,
-  module: Module<S, G, M, A>
+  module: Module<S, G, M, A, Modules>
 ): { actions: ActionTree<any, any>; injectStore: (store: Store<any>) => void } {
   const actions: any = new Actions()
   const options: ActionTree<any, any> = {}

--- a/src/register.ts
+++ b/src/register.ts
@@ -6,7 +6,7 @@ export function registerModule(
   store: Store<any>,
   path: string | string[],
   namespace: string | null,
-  module: Module<any, any, any, any>,
+  module: Module<any, any, any, any, any>,
   options?: ModuleOptions
 ): void {
   const normalizedPath = typeof path === 'string' ? [path] : path
@@ -20,7 +20,7 @@ export function registerModule(
 
 export function unregisterModule(
   store: Store<any>,
-  module: Module<any, any, any, any>
+  module: Module<any, any, any, any, any>
 ): void {
   assert(module.path, 'The module seems not registered in the store')
   store.unregisterModule(module.path!)

--- a/test/nested.spec.ts
+++ b/test/nested.spec.ts
@@ -1,0 +1,64 @@
+import * as assert from 'power-assert'
+import { createStore, Getters, Mutations, Actions, Module } from '../src'
+
+describe('Nested modules', () => {
+  class FooState {
+    value = 1
+  }
+
+  class FooGetters extends Getters<FooState> {
+    get double(): number {
+      return this.state.value * 2
+    }
+  }
+
+  class FooMutations extends Mutations<FooState> {
+    inc(amount: number) {
+      this.state.value += amount
+    }
+  }
+
+  class FooActions extends Actions<
+    FooState,
+    FooGetters,
+    FooMutations,
+    FooActions
+  > {
+    inc(amount: number) {
+      this.commit('inc', amount)
+    }
+  }
+
+  let foo: Module<FooState, FooGetters, FooMutations, FooActions, any>
+  beforeEach(() => {
+    foo = new Module({
+      state: FooState,
+      getters: FooGetters,
+      mutations: FooMutations,
+      actions: FooActions,
+    })
+  })
+
+  it('allows to access to nested module via a parent context', () => {
+    const root = new Module({
+      modules: {
+        foo,
+      },
+    })
+
+    const store = createStore(root)
+    const ctx = root.context(store)
+    const fooCtx = ctx.modules.foo
+
+    assert(fooCtx.state.value === 1)
+    assert(fooCtx.getters.double === 2)
+
+    fooCtx.commit('inc', 1)
+    assert(fooCtx.state.value === 2)
+    assert(fooCtx.getters.double === 4)
+
+    fooCtx.dispatch('inc', 2)
+    assert(fooCtx.state.value === 4)
+    assert(fooCtx.getters.double === 8)
+  })
+})

--- a/test/register.spec.ts
+++ b/test/register.spec.ts
@@ -22,7 +22,7 @@ class TestMutations extends Mutations<TestState> {
   }
 }
 
-let test: Module<TestState, never, TestMutations, any>
+let test: Module<TestState, never, TestMutations, any, any>
 
 beforeEach(() => {
   test = new Module({


### PR DESCRIPTION
fix #208 

This PR allows us to access nested modules' contexts through a parent module context.

For example, when the root module has counter and todo modules as its nested modules:

```ts
// Counter module
const counter = new Module({
  // ...
})

// Todo module
const todo = new Module({
  // ...
})

// Root module
const root = new Module({
  modules: {
    counter,
    todo
  }
})
```

You can access counter and todo context through the root module context via `modules` property.

```ts
import { root, store } from './store'

// Get root context
const ctx = root.context(store)

// You can access counter and todo context through `modules` as well
const counterCtx = ctx.modules.counter
const todoCtx = ctx.modules.todo

counterCtx.dispatch('increment')
todoCtx.dispatch('fetchTodos')
```