### PR TITLE
fix: inject store instance when `hotUpdate` options from `getStoreOptions`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,12 @@ export function createStore(
   rootModule: Module<any, any, any, any, any>,
   options: StoreOptions<any> = {}
 ): Store<any> {
-  const rootModuleOptions = rootModule.getStoreOptions()
+  const { options: rootModuleOptions, injectStore } = rootModule.create([], '')
 
   const store: Store<any> = new Store({
     ...rootModuleOptions,
     ...options,
-    plugins: rootModuleOptions.plugins.concat(options.plugins || []),
+    plugins: [injectStore].concat(options.plugins || []),
   })
 
   return store

--- a/src/module.ts
+++ b/src/module.ts
@@ -133,10 +133,29 @@ export class Module<
   }
 
   getStoreOptions() {
+    const injectStoreActionName = 'vuex-smart-module/injectStore'
     const { options, injectStore } = this.create([], '')
+
+    if (!options.actions) {
+      options.actions = {}
+    }
+    options.actions[injectStoreActionName] = function () {
+      injectStore(this)
+    }
+
+    const plugin = (store: Store<any>) => {
+      store.dispatch(injectStoreActionName)
+
+      const originalHotUpdate = store.hotUpdate
+      store.hotUpdate = (options) => {
+        originalHotUpdate.call(store, options)
+        store.dispatch(injectStoreActionName)
+      }
+    }
+
     return {
       ...options,
-      plugins: [injectStore],
+      plugins: [plugin],
     }
   }
 


### PR DESCRIPTION
fix #239 

As Nuxt automatically call `Store#hotUpdate`, we need to provide a way to do hot update without using `hotUpdate` from vuex-smart-module.

To do that, this PR patches `Store#hotUpdate` method in the plugin returned from `getStoreOptions` and the patched method tries to inject store instance on every call for `hotUpdate`.