### PR TITLE
fix: allow to use `actions` and `mutations` of nested contexts

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -250,7 +250,8 @@ export class Context<Mod extends Module<any, any, any, any, any>> {
 
   get modules(): ModulesContexts<Mod> {
     const modules = {} as ModulesContexts<Mod>
-    const children = this.moduleOptions.modules
+    const children: Record<string, Module<any, any, any, any, any>> = this
+      .moduleOptions.modules
     if (!children) {
       return modules
     }
@@ -262,7 +263,7 @@ export class Context<Mod extends Module<any, any, any, any, any>> {
           return new Context(
             createLazyContextPosition(child),
             this.store,
-            child
+            child.options
           )
         },
       })

--- a/test/nested.spec.ts
+++ b/test/nested.spec.ts
@@ -60,4 +60,27 @@ describe('Nested modules', () => {
     expect(fooCtx.state.value).toBe(4)
     expect(fooCtx.getters.double).toBe(8)
   })
+
+  it("allows to access to nested module's actions and mutations", () => {
+    const root = new Module({
+      modules: {
+        foo,
+      },
+    })
+
+    const store = createStore(root)
+    const ctx = root.context(store)
+    const fooCtx = ctx.modules.foo
+
+    expect(fooCtx.state.value).toBe(1)
+    expect(fooCtx.getters.double).toBe(2)
+
+    fooCtx.mutations.inc(1)
+    expect(fooCtx.state.value).toBe(2)
+    expect(fooCtx.getters.double).toBe(4)
+
+    fooCtx.actions.inc(2)
+    expect(fooCtx.state.value).toBe(4)
+    expect(fooCtx.getters.double).toBe(8)
+  })
 })


### PR DESCRIPTION
fix #242 