### PR TITLE
fix: allow mocking `mutations` and `actions` in an action test

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -17,16 +17,31 @@ export function inject<G extends Getters<S>, S>(
   Getters: Class<G>,
   injection: DeepPartial<G & { state: S; getters: G }>
 ): G
+
 export function inject<M extends Mutations<S>, S>(
   Mutations: Class<M>,
   injection: DeepPartial<M & { state: S }>
 ): M
-export function inject<A extends Actions<S, G, any, any>, S, G extends BG<S>>(
+
+export function inject<
+  A extends Actions<S, G, M, A>,
+  S,
+  G extends BG<S>,
+  M extends BM<S>
+>(
   Actions: Class<A>,
   injection: DeepPartial<
-    A & { state: S; getters: G; dispatch: any; commit: any }
+    A & {
+      state: S
+      getters: G
+      dispatch: any
+      commit: any
+      mutations: M
+      actions: A
+    }
   >
 ): A
+
 export function inject<T>(
   F: Class<T>,
   injection: DeepPartial<T> & Record<string, any>

--- a/test/testability.spec.ts
+++ b/test/testability.spec.ts
@@ -28,6 +28,14 @@ class TestActions extends Actions<
   inc() {
     this.commit('inc', undefined)
   }
+
+  incBypass() {
+    this.actions.inc()
+  }
+
+  incCall() {
+    this.mutations.inc()
+  }
 }
 
 const test = new Module({
@@ -79,13 +87,34 @@ describe('testability', () => {
     expect(state.count).toBe(11)
   })
 
-  it('tests actions', (done) => {
+  it('tests actions', () => {
+    const commit = jest.fn()
     const actions = inject(TestActions, {
-      commit(type: string) {
-        expect(type).toBe('inc')
-        done()
-      },
+      commit,
     })
     actions.inc()
+    expect(commit).toHaveBeenCalledWith('inc', undefined)
+  })
+
+  it('mocks actions in an action', () => {
+    const inc = jest.fn()
+    const actions = inject(TestActions, {
+      actions: {
+        inc,
+      },
+    })
+    actions.incBypass()
+    expect(inc).toHaveBeenCalled()
+  })
+
+  it('mocks mutations in an action', () => {
+    const inc = jest.fn()
+    const actions = inject(TestActions, {
+      mutations: {
+        inc,
+      },
+    })
+    actions.incCall()
+    expect(inc).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
fix #255 