### PR TITLE
fix: avoid producing vuex warning with multiple getters in the same namespace

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -268,29 +268,37 @@ function initGetters<
     return proxy
   }
 
-  traverseDescriptors(Getters.prototype, BaseGetters, (desc, key) => {
-    if (typeof desc.value !== 'function' && !desc.get) {
-      return
-    }
-
-    const methodFn = desc.value
-    const getterFn = desc.get
-
-    options[key] = () => {
-      const proxy =
-        process.env.NODE_ENV === 'production'
-          ? getters
-          : proxyGetters(getters, key)
-
-      if (getterFn) {
-        return getterFn.call(proxy)
+  traverseDescriptors(
+    Getters.prototype,
+    BaseGetters,
+    (desc, key) => {
+      if (typeof desc.value !== 'function' && !desc.get) {
+        return
       }
 
-      if (methodFn) {
-        return methodFn.bind(proxy)
+      const methodFn = desc.value
+      const getterFn = desc.get
+
+      options[key] = () => {
+        const proxy =
+          process.env.NODE_ENV === 'production'
+            ? getters
+            : proxyGetters(getters, key)
+
+        if (getterFn) {
+          return getterFn.call(proxy)
+        }
+
+        if (methodFn) {
+          return methodFn.bind(proxy)
+        }
       }
+    },
+    {
+      constructor: true,
+      $init: true,
     }
-  })
+  )
 
   return {
     getters: options,
@@ -395,19 +403,27 @@ function initActions<
     return proxy
   }
 
-  traverseDescriptors(Actions.prototype, BaseActions, (desc, key) => {
-    if (typeof desc.value !== 'function') {
-      return
-    }
+  traverseDescriptors(
+    Actions.prototype,
+    BaseActions,
+    (desc, key) => {
+      if (typeof desc.value !== 'function') {
+        return
+      }
 
-    options[key] = (_: any, payload: any) => {
-      const proxy =
-        process.env.NODE_ENV === 'production'
-          ? actions
-          : proxyActions(actions, key)
-      return actions[key].call(proxy, payload)
+      options[key] = (_: any, payload: any) => {
+        const proxy =
+          process.env.NODE_ENV === 'production'
+            ? actions
+            : proxyActions(actions, key)
+        return actions[key].call(proxy, payload)
+      }
+    },
+    {
+      constructor: true,
+      $init: true,
     }
-  })
+  )
 
   return {
     actions: options,

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -800,6 +800,47 @@ describe('Module', () => {
     expect(store.state.foo.value).toBe(3)
   })
 
+  it('do not produce vuex getter warning with $init', () => {
+    jest.spyOn(console, 'error')
+    const fooSpy = jest.fn()
+    const barSpy = jest.fn()
+
+    class FooGetters extends Getters {
+      $init() {
+        fooSpy()
+      }
+    }
+
+    class BarGetters extends Getters {
+      $init() {
+        barSpy()
+      }
+    }
+
+    const foo = new Module({
+      namespaced: false,
+      getters: FooGetters,
+    })
+
+    const bar = new Module({
+      namespaced: false,
+      getters: BarGetters,
+    })
+
+    const root = new Module({
+      modules: {
+        foo,
+        bar,
+      },
+    })
+
+    createStore(root)
+
+    expect(fooSpy).toHaveBeenCalled()
+    expect(barSpy).toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
   describe('component mappers', () => {
     const fooModule = new Module({
       state: FooState,


### PR DESCRIPTION
fix #294 