### PR TITLE
Fix typo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ import { foo } from '@/store/modules/foo'
 
 export default Vue.extend({
   mounted() {
-    const ctx = foo.context(this.store)
+    const ctx = foo.context(this.$store)
 
     // Call `increment` action
     ctx.actions.increment(1)


### PR DESCRIPTION
Hi @ktsn thank u for this great lib. 
I'm on a route to integrate it at my new job project. 
While I was reading the docs I encountered PROBABLY on typo at `Method Style Access for Actions and Mutations`.
If no there's a question: what is `this.store` in this case? 