### PR TITLE
avoid reusing context between stores

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -305,11 +305,10 @@ function initGetters<
     injectStore: (store) => {
       const context = module.context(store)
 
-      if (!getters.hasOwnProperty('__ctx__')) {
-        Object.defineProperty(getters, '__ctx__', {
-          get: () => context,
-        })
-      }
+      Object.defineProperty(getters, '__ctx__', {
+        get: () => context,
+        configurable: true,
+      })
 
       getters.$init(store)
     },
@@ -365,11 +364,10 @@ function initMutations<
     injectStore: (store) => {
       const context = module.context(store)
 
-      if (!mutations.hasOwnProperty('__ctx__')) {
-        Object.defineProperty(mutations, '__ctx__', {
-          get: () => context,
-        })
-      }
+      Object.defineProperty(mutations, '__ctx__', {
+        get: () => context,
+        configurable: true,
+      })
     },
   }
 }
@@ -430,11 +428,10 @@ function initActions<
     injectStore: (store) => {
       const context = module.context(store)
 
-      if (!actions.hasOwnProperty('__ctx__')) {
-        Object.defineProperty(actions, '__ctx__', {
-          get: () => context,
-        })
-      }
+      Object.defineProperty(actions, '__ctx__', {
+        get: () => context,
+        configurable: true,
+      })
 
       actions.$init(store)
     },


### PR DESCRIPTION
fix #360 

On SSR environment, created modules are reused while the store is recreated for each request. We avoid reassigning `__ctx__` object to avoid a redefinition error at #263 but it actually lets modules keep accessing the old store instance.

To deal with this issue, we have to actually redefine `__ctx__` object everytime we recreate the store.